### PR TITLE
Add Jest testing for shuffleDirections

### DIFF
--- a/Maze Visualizer/shuffleDirections.js
+++ b/Maze Visualizer/shuffleDirections.js
@@ -1,0 +1,20 @@
+const directions = {
+  N: [-1, 0],
+  E: [0, 1],
+  S: [1, 0],
+  W: [0, -1],
+};
+
+function shuffleDirections() {
+  const directionsArray = Object.values(directions);
+  for (let i = directionsArray.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [directionsArray[i], directionsArray[j]] = [
+      directionsArray[j],
+      directionsArray[i],
+    ];
+  }
+  return directionsArray;
+}
+
+module.exports = { shuffleDirections, directions };

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "author": "",
   "license": "ISC",
@@ -13,6 +13,7 @@
     "eslint": "^9.12.0",
     "eslint-plugin-react": "^7.37.1",
     "globals": "^15.11.0",
-    "typescript-eslint": "^8.8.1"
+    "typescript-eslint": "^8.8.1",
+    "jest": "^29.7.0"
   }
 }

--- a/tests/shuffleDirections.test.js
+++ b/tests/shuffleDirections.test.js
@@ -1,0 +1,18 @@
+const { shuffleDirections, directions } = require('../Maze Visualizer/shuffleDirections');
+
+test('shuffleDirections returns all directions', () => {
+  const expected = Object.values(directions);
+  const result = shuffleDirections();
+  expect(result).toEqual(expect.arrayContaining(expected));
+  expect(result.length).toBe(expected.length);
+});
+
+test('shuffleDirections returns varying order', () => {
+  const orders = new Set();
+  for (let i = 0; i < 10; i++) {
+    const res = shuffleDirections().map(d => d.join(','));
+    orders.add(res.join('|'));
+  }
+  // there should be more than one unique order
+  expect(orders.size).toBeGreaterThan(1);
+});


### PR DESCRIPTION
## Summary
- add a shuffleDirections module for reuse
- test shuffleDirections with Jest
- configure Jest in package.json

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5c9b85e48328824602cd8d4da42b